### PR TITLE
Provide a console for STDERR and STDOUT

### DIFF
--- a/xi-win-shell/Cargo.toml
+++ b/xi-win-shell/Cargo.toml
@@ -15,4 +15,4 @@ time = "0.1.39"
 
 [dependencies.winapi]
 version = "0.3.6"
-features = ["d2d1_1", "dwrite", "winbase", "libloaderapi", "errhandlingapi", "winuser", "shellscalingapi", "shobjidl", "combaseapi", "synchapi", "dxgi1_3", "dcomp", "d3d11", "dwmapi"]
+features = ["d2d1_1", "dwrite", "winbase", "libloaderapi", "errhandlingapi", "winuser", "shellscalingapi", "shobjidl", "combaseapi", "synchapi", "dxgi1_3", "dcomp", "d3d11", "dwmapi", "wincon", "fileapi", "processenv", "winbase"]

--- a/xi-win-shell/src/util.rs
+++ b/xi-win-shell/src/util.rs
@@ -19,9 +19,10 @@
 
 use std::ffi::{OsStr, OsString, CString};
 use std::fmt;
-use std::os::windows::ffi::{OsStrExt, OsStringExt};
-use std::slice;
 use std::mem;
+use std::os::windows::ffi::{OsStrExt, OsStringExt};
+use std::ptr;
+use std::slice;
 
 use winapi::ctypes::c_void;
 use winapi::shared::guiddef::REFIID;
@@ -29,9 +30,16 @@ use winapi::shared::minwindef::*;
 use winapi::shared::ntdef::*;
 use winapi::shared::windef::*;
 use winapi::shared::winerror::SUCCEEDED;
+use winapi::um::fileapi::*;
+use winapi::um::handleapi::*;
 use winapi::um::libloaderapi::*;
+use winapi::um::processenv::*;
 use winapi::um::shellscalingapi::*;
 use winapi::um::unknwnbase::IUnknown;
+use winapi::um::winbase::*;
+use winapi::um::wincon::*;
+// This needs to be explicit, otherwise HRESULT will conflict
+use winapi::um::winnt::{GENERIC_READ, GENERIC_WRITE, FILE_SHARE_WRITE};
 
 use direct2d::enums::DrawTextOptions;
 
@@ -227,6 +235,7 @@ lazy_static! {
 
 /// Initialize the app. At the moment, this is mostly needed for hi-dpi.
 pub fn init() {
+    attach_console();
     if let Some(func) = OPTIONAL_FUNCTIONS.SetProcessDpiAwareness {
         // This function is only supported on windows 10
         unsafe {
@@ -257,3 +266,30 @@ macro_rules! accel {
         ]
     }
 }
+
+/// Attach the process to the console of the parent process. This allows xi-win to
+/// correctly print to a console when run from powershell or cmd.
+/// If no console is available, allocate a new console.
+fn attach_console() {
+    unsafe {
+        if AttachConsole(ATTACH_PARENT_PROCESS) > 0 {
+            let chnd = CreateFileA(
+                CString::new("CONOUT$").unwrap().as_ptr(),
+                GENERIC_READ | GENERIC_WRITE,
+                FILE_SHARE_WRITE,
+                ptr::null_mut(),
+                OPEN_EXISTING,
+                0,
+                ptr::null_mut());
+
+            if chnd == INVALID_HANDLE_VALUE {
+                // CreateFileA failed.
+                return;
+            }
+
+            SetStdHandle(STD_OUTPUT_HANDLE, chnd);
+            SetStdHandle(STD_ERROR_HANDLE, chnd);
+        }
+    }
+}
+


### PR DESCRIPTION
Provide a new console or attach to a parent console so that STDERR and STDOUT are properly redirected. This enables eprintln! and println! writes.