### PR TITLE
Add flex to row/column layout

### DIFF
--- a/xi-win-ui/examples/calc.rs
+++ b/xi-win-ui/examples/calc.rs
@@ -164,41 +164,56 @@ fn op_button(ui: &mut UiState, op: char) -> Id
     op_button_label(ui, op, op.to_string())
 }
 
+// Create a row where all children are flex
+fn flex_row(children: &[Id], ui: &mut UiState) -> Id {
+    let mut row = Row::new();
+    for child in children {
+        row.set_flex(*child, 1.0);
+    }
+    row.ui(children, ui)
+}
+
 fn build_calc(ui: &mut UiState) {
     let display = Label::new("0".to_string()).ui(ui);
     let row0 = pad(display, ui);
 
-    let row1 = Row::new().ui(&[
+    let row1 = flex_row(&[
         op_button_label(ui, 'c', "CE".to_string()),
         op_button(ui, 'C'),
         op_button(ui, '⌫'),
         op_button(ui, '÷'),
     ], ui);
-    let row2 = Row::new().ui(&[
+    let row2 = flex_row(&[
         digit_button(ui, 7),
         digit_button(ui, 8),
         digit_button(ui, 9),
         op_button(ui, '×'),
     ], ui);
-    let row3 = Row::new().ui(&[
+    let row3 = flex_row(&[
         digit_button(ui, 4),
         digit_button(ui, 5),
         digit_button(ui, 6),
         op_button(ui, '−'),
     ], ui);
-    let row4 = Row::new().ui(&[
+    let row4 = flex_row(&[
         digit_button(ui, 1),
         digit_button(ui, 2),
         digit_button(ui, 3),
         op_button(ui, '+'),
     ], ui);
-    let row5 = Row::new().ui(&[
+    let row5 = flex_row(&[
         op_button(ui, '±'),
         digit_button(ui, 0),
         op_button(ui, '.'),
         op_button(ui, '='),
     ], ui);
-    let panel = Column::new().ui(&[row0, row1, row2, row3, row4, row5], ui);
+    let mut column = Column::new();
+    column.set_flex(row1, 1.0);
+    column.set_flex(row2, 1.0);
+    column.set_flex(row3, 1.0);
+    column.set_flex(row4, 1.0);
+    column.set_flex(row5, 1.0);
+    let panel = column.ui(&[row0, row1, row2, row3, row4, row5], ui);
     let key_listener = KeyListener::new().ui(panel, ui);
     let forwarder = EventForwarder::<CalcAction>::new().ui(key_listener, ui);
     let mut calc_state = CalcState {

--- a/xi-win-ui/src/widget/flex.rs
+++ b/xi-win-ui/src/widget/flex.rs
@@ -59,6 +59,17 @@ struct Params {
     flex: f32,
 }
 
+impl Params {
+    // Determine the phase in which this child should be measured.
+    fn get_flex_phase(&self) -> Phase {
+        if self.flex == 0.0 {
+            Phase::NonFlex
+        } else {
+            Phase::Flex
+        }
+    }
+}
+
 impl Axis {
     fn major(&self, coords: (f32, f32)) -> f32 {
         match *self {
@@ -140,7 +151,7 @@ impl Flex {
     /// the specified phase.
     fn get_next_child(&self, children: &[Id], start: usize, phase: Phase) -> Option<usize> {
         for ix in start..children.len() {
-            if (self.get_params(children[ix]).flex == 0.0) == (phase == Phase::NonFlex) {
+            if self.get_params(children[ix]).get_flex_phase() == phase {
                 return Some(ix);
             }
         }

--- a/xi-win-ui/src/widget/flex.rs
+++ b/xi-win-ui/src/widget/flex.rs
@@ -14,6 +14,8 @@
 
 //! A widget that arranges its children in a one-dimensional array.
 
+use std::collections::BTreeMap;
+
 use {BoxConstraints, LayoutResult};
 use {Id, LayoutCtx, UiInner};
 use widget::Widget;
@@ -22,17 +24,39 @@ pub struct Row;
 pub struct Column;
 
 pub struct Flex {
+    params: BTreeMap<Id, Params>,
     direction: Axis,
 
     // layout continuation state
+
+    phase: Phase,
     ix: usize,
-    major_per_flex: f32,
     minor: f32,
+
+    // the total measure of non-flex children
+    total_non_flex: f32,
+
+    // the sum of flex parameters of all children
+    flex_sum: f32,
 }
 
 pub enum Axis {
     Horizontal,
     Vertical,
+}
+
+// Layout happens in two phases. First, the non-flex children
+// are laid out. Then, the remaining space is divided across
+// the flex children.
+#[derive(Clone, Copy, PartialEq)]
+enum Phase {
+    NonFlex,
+    Flex,
+}
+
+#[derive(Copy, Clone, Default)]
+struct Params {
+    flex: f32,
 }
 
 impl Axis {
@@ -61,11 +85,14 @@ impl Axis {
 impl Row {
     pub fn new() -> Flex {
         Flex {
+            params: BTreeMap::new(),
             direction: Axis::Horizontal,
 
+            phase: Phase::NonFlex,
             ix: 0,
-            major_per_flex: 0.0,
             minor: 0.0,
+            total_non_flex: 0.0,
+            flex_sum: 0.0,
         }
     }
 }
@@ -73,18 +100,65 @@ impl Row {
 impl Column {
     pub fn new() -> Flex {
         Flex {
+            params: BTreeMap::new(),
             direction: Axis::Vertical,
 
+            phase: Phase::NonFlex,
             ix: 0,
-            major_per_flex: 0.0,
             minor: 0.0,
+            total_non_flex: 0.0,
+            flex_sum: 0.0,
         }
     }
 }
 
 impl Flex {
+    /// Add to UI with children.
     pub fn ui(self, children: &[Id], ctx: &mut UiInner) -> Id {
         ctx.add(self, children)
+    }
+
+    /// Set the flex for a child widget.
+    ///
+    /// This function is used to set flex for a child widget, and is done while
+    /// building, before adding to the UI. Likely we will need to think of other
+    /// mechanisms to change parameters dynamically after building.
+    pub fn set_flex(&mut self, child: Id, flex: f32) {
+        let params = self.get_params_mut(child);
+        params.flex = flex;
+    }
+
+    fn get_params_mut(&mut self, child: Id) -> &mut Params {
+        self.params.entry(child).or_default()
+    }
+
+    fn get_params(&self, child: Id) -> Params {
+        self.params.get(&child).cloned().unwrap_or(Default::default())
+    }
+
+    /// Return the index (within `children`) of the next child that belongs in
+    /// the specified phase.
+    fn get_next_child(&self, children: &[Id], start: usize, phase: Phase) -> Option<usize> {
+        for ix in start..children.len() {
+            if (self.get_params(children[ix]).flex == 0.0) == (phase == Phase::NonFlex) {
+                return Some(ix);
+            }
+        }
+        None
+    }
+
+    /// Position all children, after the children have all been measured.
+    fn finish_layout(&self, bc: &BoxConstraints, children: &[Id], ctx: &mut LayoutCtx)
+        -> LayoutResult
+    {
+        let mut major = 0.0;
+        for &child in children {
+            // top-align, could do center etc. based on child height
+            ctx.position_child(child, self.direction.pack(major, 0.0));
+            major += self.direction.major(ctx.get_child_size(child));
+        }
+        let total_major = self.direction.major((bc.max_width, bc.max_height));
+        LayoutResult::Size(self.direction.pack(total_major, self.minor))
     }
 }
 
@@ -95,39 +169,61 @@ impl Widget for Flex {
         if let Some(size) = size {
             let minor = self.direction.minor(size);
             self.minor = self.minor.max(minor);
-            self.ix += 1;
-            if self.ix == children.len() {
-                // measured all children
-                let mut major = 0.0;
-                for &child in children {
-                    // top-align, could do center etc. based on child height
-                    ctx.position_child(child, self.direction.pack(major, 0.0));
-                    major += self.major_per_flex;
+            if self.phase == Phase::NonFlex {
+                self.total_non_flex += self.direction.major(size);
+            }
+
+            // Advance to the next child; finish non-flex phase if at end.
+            if let Some(ix) = self.get_next_child(children, self.ix + 1, self.phase) {
+                self.ix = ix;
+            } else if self.phase == Phase::NonFlex {
+                if let Some(ix) = self.get_next_child(children, 0, Phase::Flex) {
+                    self.ix = ix;
+                    self.phase = Phase::Flex;
+                } else {
+                    return self.finish_layout(bc, children, ctx);
                 }
-                let max_major = self.direction.major((bc.max_width, bc.max_height));
-                return LayoutResult::Size(self.direction.pack(max_major, self.minor));
+            } else {
+                return self.finish_layout(bc, children, ctx)
             }
         } else {
+            // Start layout process, no children measured yet.
             if children.is_empty() {
                 return LayoutResult::Size((bc.min_width, bc.min_height));
             }
-            self.ix = 0;
+            if let Some(ix) = self.get_next_child(children, 0, Phase::NonFlex) {
+                self.ix = ix;
+                self.phase = Phase::NonFlex;
+            } else {
+                // All children are flex, skip non-flex pass.
+                self.ix = 0;
+                self.phase = Phase::Flex;
+            }
+            self.total_non_flex = 0.0;
+            self.flex_sum = children.iter().map(|id| self.get_params(*id).flex).sum();
             self.minor = self.direction.minor((bc.min_width, bc.min_height));
-            let max_major = self.direction.major((bc.max_width, bc.max_height));
-            self.major_per_flex = max_major / (children.len() as f32);
         }
+        let (min_major, max_major) = if self.phase == Phase::NonFlex {
+            (0.0, ::std::f32::INFINITY)
+        } else {
+            let total_major = self.direction.major((bc.max_width, bc.max_height));
+            // TODO: should probably max with 0.0 to avoid negative sizes
+            let remaining = total_major - self.total_non_flex;
+            let major = remaining * self.get_params(children[self.ix]).flex / self.flex_sum;
+            (major, major)
+        };
         let child_bc = match self.direction {
             Axis::Horizontal => BoxConstraints {
-                min_width: self.major_per_flex,
-                max_width: self.major_per_flex,
+                min_width: min_major,
+                max_width: max_major,
                 min_height: bc.min_height,
                 max_height: bc.max_height,
             },
             Axis::Vertical => BoxConstraints {
                 min_width: bc.min_width,
                 max_width: bc.max_width,
-                min_height: self.major_per_flex,
-                max_height: self.major_per_flex,
+                min_height: min_major,
+                max_height: max_major,
             },
         };
         LayoutResult::RequestChild(children[self.ix], child_bc)


### PR DESCRIPTION
Each child widget can be either non-flex (indicated by a default flex
value of 0.0) or can be flex, getting a proportionate amount of the
space left after the non-flex children are allocated.

Right now, there's a simple way to set flex in the builder for row or
column widgets, but no real solution for dynamic changes, either setting
new children added or changing the value for existing children.