### PR TITLE
Start working on graph mutation

### DIFF
--- a/xi-win-ui/examples/anim.rs
+++ b/xi-win-ui/examples/anim.rs
@@ -25,7 +25,7 @@ use direct2d::RenderTarget;
 use xi_win_shell::win_main;
 use xi_win_shell::window::WindowBuilder;
 
-use xi_win_ui::{UiMain, UiState, UiInner};
+use xi_win_ui::{UiMain, UiState, Ui};
 
 use xi_win_ui::{BoxConstraints, Geometry, LayoutResult};
 use xi_win_ui::{HandlerCtx, Id, LayoutCtx, MouseEvent, PaintCtx};
@@ -68,7 +68,7 @@ impl Widget for AnimWidget {
 }
 
 impl AnimWidget {
-    fn ui(self, ctx: &mut UiInner) -> Id {
+    fn ui(self, ctx: &mut Ui) -> Id {
         ctx.add(self, &[])
     }
 }

--- a/xi-win-ui/examples/sample.rs
+++ b/xi-win-ui/examples/sample.rs
@@ -26,7 +26,7 @@ use xi_win_shell::menu::Menu;
 use xi_win_shell::win_main;
 use xi_win_shell::window::WindowBuilder;
 
-use xi_win_ui::{UiMain, UiState, UiInner};
+use xi_win_ui::{UiMain, UiState, Ui};
 use xi_win_ui::widget::{Button, Row, Padding};
 
 use xi_win_ui::{BoxConstraints, Geometry, LayoutResult};
@@ -55,7 +55,7 @@ impl Widget for FooWidget {
 }
 
 impl FooWidget {
-    fn ui(self, ctx: &mut UiInner) -> Id {
+    fn ui(self, ctx: &mut Ui) -> Id {
         ctx.add(self, &[])
     }
 }

--- a/xi-win-ui/src/widget/button.rs
+++ b/xi-win-ui/src/widget/button.rs
@@ -23,7 +23,7 @@ use directwrite::{self, TextFormat, TextLayout};
 use xi_win_shell::util::default_text_options;
 
 use {BoxConstraints, Geometry, LayoutResult};
-use {HandlerCtx, Id, LayoutCtx, MouseEvent, PaintCtx, UiInner};
+use {HandlerCtx, Id, LayoutCtx, MouseEvent, PaintCtx, Ui};
 use widget::Widget;
 
 /// A text label with no interaction.
@@ -43,7 +43,7 @@ impl Label {
         }
     }
 
-    pub fn ui(self, ctx: &mut UiInner) -> Id {
+    pub fn ui(self, ctx: &mut Ui) -> Id {
         ctx.add(self, &[])
     }
 
@@ -99,7 +99,7 @@ impl Button {
         }
     }
 
-    pub fn ui(self, ctx: &mut UiInner) -> Id {
+    pub fn ui(self, ctx: &mut Ui) -> Id {
         ctx.add(self, &[])
     }
 }

--- a/xi-win-ui/src/widget/event_forwarder.rs
+++ b/xi-win-ui/src/widget/event_forwarder.rs
@@ -18,7 +18,7 @@ use std::any::Any;
 use std::marker::PhantomData;
 
 use widget::Widget;
-use {HandlerCtx, Id, UiInner};
+use {HandlerCtx, Id, Ui};
 
 pub struct EventForwarder<T>(PhantomData<T>);
 
@@ -27,7 +27,7 @@ impl<T: Any + Clone> EventForwarder<T> {
         EventForwarder(Default::default())
     }
 
-    pub fn ui(self, child: Id, ctx: &mut UiInner) -> Id {
+    pub fn ui(self, child: Id, ctx: &mut Ui) -> Id {
         ctx.add(self, &[child])
     }
 }

--- a/xi-win-ui/src/widget/flex.rs
+++ b/xi-win-ui/src/widget/flex.rs
@@ -17,7 +17,7 @@
 use std::collections::BTreeMap;
 
 use {BoxConstraints, LayoutResult};
-use {Id, LayoutCtx, UiInner};
+use {Id, LayoutCtx, Ui};
 use widget::Widget;
 
 pub struct Row;
@@ -125,7 +125,7 @@ impl Column {
 
 impl Flex {
     /// Add to UI with children.
-    pub fn ui(self, children: &[Id], ctx: &mut UiInner) -> Id {
+    pub fn ui(self, children: &[Id], ctx: &mut Ui) -> Id {
         ctx.add(self, children)
     }
 

--- a/xi-win-ui/src/widget/key_listener.rs
+++ b/xi-win-ui/src/widget/key_listener.rs
@@ -18,7 +18,7 @@ use winapi::um::winuser::*;
 use xi_win_shell::window::M_ALT;
 
 use widget::Widget;
-use {HandlerCtx, Id, KeyEvent, KeyVariant, UiInner};
+use {HandlerCtx, Id, KeyEvent, KeyVariant, Ui};
 
 pub struct KeyListener;
 
@@ -27,7 +27,7 @@ impl KeyListener {
         KeyListener
     }
 
-    pub fn ui(self, child: Id, ctx: &mut UiInner) -> Id {
+    pub fn ui(self, child: Id, ctx: &mut Ui) -> Id {
         ctx.add(self, &[child])
     }
 }

--- a/xi-win-ui/src/widget/padding.rs
+++ b/xi-win-ui/src/widget/padding.rs
@@ -15,7 +15,7 @@
 //! A widget that just adds padding during layout.
 
 use {BoxConstraints, LayoutResult};
-use {Id, LayoutCtx, UiInner};
+use {Id, LayoutCtx, Ui};
 use widget::Widget;
 
 /// A padding widget. Is expected to have exactly one child.
@@ -37,7 +37,7 @@ impl Padding {
         }
     }
 
-    pub fn ui(self, child: Id, ctx: &mut UiInner) -> Id {
+    pub fn ui(self, child: Id, ctx: &mut Ui) -> Id {
         ctx.add(self, &[child])
     }
 }


### PR DESCRIPTION
Starting to allow mutation of the graph from inside listener contexts,
not just during building.

This patch adds an `append_child` method, and also does a bit of
refactoring so that listeners can be added.

More mutation methods are needed, but this is a start.