### PR TITLE
Add file dialogs

### DIFF
--- a/xi-win-shell/examples/hello.rs
+++ b/xi-win-shell/examples/hello.rs
@@ -22,6 +22,7 @@ use direct2d::math::*;
 use direct2d::RenderTarget;
 use direct2d::brush::SolidColorBrush;
 
+use xi_win_shell::dialog::{FileDialogOptions, FileDialogType};
 use xi_win_shell::menu::Menu;
 use xi_win_shell::paint::PaintCtx;
 use xi_win_shell::win_main;
@@ -52,6 +53,12 @@ impl WinHandler for HelloState {
     fn command(&self, id: u32) {
         match id {
             0x100 => self.handle.borrow().close(),
+            0x101 => {
+                let mut options = FileDialogOptions::default();
+                options.set_show_hidden();
+                let filename = self.handle.borrow().file_dialog(FileDialogType::Open, options);
+                println!("result: {:?}", filename);
+            }
             _ => println!("unexpected id {}", id),
         }
     }
@@ -93,6 +100,7 @@ fn main() {
 
     let mut file_menu = Menu::new();
     file_menu.add_item(0x100, "E&xit");
+    file_menu.add_item(0x101, "O&pen");
     let mut menubar = Menu::new();
     menubar.add_dropdown(file_menu, "&File");
 

--- a/xi-win-shell/src/dialog.rs
+++ b/xi-win-shell/src/dialog.rs
@@ -1,0 +1,92 @@
+// Copyright 2018 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! File open/save dialogs.
+
+#![allow(non_upper_case_globals)]
+
+use winapi::Interface;
+use winapi::shared::minwindef::*;
+use winapi::shared::ntdef::LPWSTR;
+use winapi::shared::windef::*;
+use winapi::shared::wtypesbase::*;
+use winapi::um::combaseapi::*;
+use winapi::um::shobjidl::*;
+use winapi::um::shobjidl_core::*;
+use wio::com::ComPtr;
+
+use std::ptr::null_mut;
+use std::ffi::OsString;
+use util::{as_result, Error, FromWide};
+
+/// Type of file dialog.
+pub enum FileDialogType {
+    /// File open dialog.
+    Open,
+    /// File save dialog.
+    Save,
+}
+
+/// Options for file dialog.
+///
+/// See documentation for
+/// [_FILEOPENDIALOGOPTIONS](https://docs.microsoft.com/en-us/windows/desktop/api/shobjidl_core/ne-shobjidl_core-_fileopendialogoptions)
+/// for more information on the winapi implementation.
+#[derive(Default)]
+pub struct FileDialogOptions(DWORD);
+
+impl FileDialogOptions {
+    /// Include system and hidden items.
+    ///
+    /// Maps to `FOS_FORCESHOWHIDDEN` in winapi.
+    pub fn set_show_hidden(&mut self) {
+        self.0 |= FOS_FORCESHOWHIDDEN;
+    }
+
+    // TODO: more options as needed
+}
+
+// TODO: remove these when they get added to winapi
+DEFINE_GUID!{CLSID_FileOpenDialog,
+    0xDC1C5A9C, 0xE88A, 0x4DDE, 0xA5, 0xA1, 0x60, 0xF8, 0x2A, 0x20, 0xAE, 0xF7}
+DEFINE_GUID!{CLSID_FileSaveDialog,
+    0xC0B4E2F3, 0xBA21, 0x4773, 0x8D, 0xBA, 0x33, 0x5E, 0xC9, 0x46, 0xEB, 0x8B}
+
+pub(crate) unsafe fn get_file_dialog_path(hwnd_owner: HWND, ty: FileDialogType,
+    options: FileDialogOptions) -> Result<OsString, Error>
+{
+    let mut pfd: *mut IFileDialog = null_mut();
+    let (class, id) = match ty {
+        FileDialogType::Open => (&CLSID_FileOpenDialog, IFileOpenDialog::uuidof()),
+        FileDialogType::Save => (&CLSID_FileSaveDialog, IFileSaveDialog::uuidof()),
+    };
+    as_result(CoCreateInstance(class,
+            null_mut(),
+            CLSCTX_INPROC_SERVER,
+            &id,
+            &mut pfd as *mut *mut IFileDialog as *mut LPVOID
+            ))?;
+    let file_dialog = ComPtr::from_raw(pfd);
+    as_result(file_dialog.SetOptions(options.0))?;
+    as_result(file_dialog.Show(hwnd_owner))?;
+    let mut result_ptr: *mut IShellItem = null_mut();
+    as_result(file_dialog.GetResult(&mut result_ptr))?;
+    let shell_item = ComPtr::from_raw(result_ptr);
+    let mut display_name: LPWSTR = null_mut();
+    as_result(shell_item.GetDisplayName(SIGDN_FILESYSPATH, &mut display_name))?;
+    let filename = display_name.to_os_string();
+    CoTaskMemFree(display_name as LPVOID);
+
+    Ok(filename)
+}

--- a/xi-win-shell/src/lib.rs
+++ b/xi-win-shell/src/lib.rs
@@ -14,6 +14,7 @@
 
 //! Windows-specific application shell used for xi editor.
 
+#[macro_use]
 extern crate winapi;
 extern crate direct2d;
 extern crate wio;
@@ -21,6 +22,7 @@ extern crate wio;
 extern crate lazy_static;
 
 mod dcomp;
+pub mod dialog;
 pub mod menu;
 pub mod paint;
 pub mod util;

--- a/xi-win-shell/src/window.rs
+++ b/xi-win-shell/src/window.rs
@@ -18,6 +18,7 @@
 
 use std::any::Any;
 use std::cell::{Cell, RefCell};
+use std::ffi::OsString;
 use std::mem;
 use std::ptr::{null, null_mut};
 use std::rc::{Rc, Weak};
@@ -44,6 +45,7 @@ use direct2d::math::SizeU;
 use direct2d::render_target::{GenericRenderTarget, HwndRenderTarget, RenderTarget};
 
 use Error;
+use dialog::{FileDialogOptions, FileDialogType, get_file_dialog_path};
 use dcomp::{D3D11Device, DCompositionDevice, DCompositionTarget, DCompositionVisual};
 use menu::Menu;
 use paint::{self, PaintCtx};
@@ -879,6 +881,12 @@ impl WindowHandle {
         self.0.upgrade().map(|w| w.hwnd.get())
     }
 
+    pub fn file_dialog(&self, ty: FileDialogType, options: FileDialogOptions)
+        -> Result<OsString, Error>
+    {
+        let hwnd = self.get_hwnd().ok_or(Error::Null)?;
+        unsafe { get_file_dialog_path(hwnd, ty, options) }
+    }
 
     /// Get a handle that can be used to schedule an idle task.
     pub fn get_idle_handle(&self) -> Option<IdleHandle> {

--- a/xi-win-ui/examples/sample.rs
+++ b/xi-win-ui/examples/sample.rs
@@ -28,12 +28,14 @@ use xi_win_shell::window::WindowBuilder;
 
 use xi_win_ui::{UiMain, UiState, UiInner};
 use xi_win_ui::widget::{Button, Row, Padding};
+use xi_win_ui::{FileDialogOptions, FileDialogType};
 
 use xi_win_ui::{BoxConstraints, Geometry, LayoutResult};
 use xi_win_ui::{Id, LayoutCtx, PaintCtx};
 use xi_win_ui::widget::Widget;
 
 const COMMAND_EXIT: u32 = 0x100;
+const COMMAND_OPEN: u32 = 0x101;
 
 /// A very simple custom widget.
 struct FooWidget;
@@ -65,6 +67,7 @@ fn main() {
 
     let mut file_menu = Menu::new();
     file_menu.add_item(COMMAND_EXIT, "E&xit");
+    file_menu.add_item(COMMAND_OPEN, "O&pen");
     let mut menubar = Menu::new();
     menubar.add_dropdown(file_menu, "&File");
 
@@ -91,6 +94,11 @@ fn main() {
     state.set_command_listener(|cmd, mut ctx| {
         match cmd {
             COMMAND_EXIT => ctx.close(),
+            COMMAND_OPEN => {
+                let options = FileDialogOptions::default();
+                let result = ctx.file_dialog(FileDialogType::Open, options);
+                println!("result = {:?}", result);
+            }
             _ => println!("unexpected command {}", cmd),
         }
     });

--- a/xi-win-ui/src/lib.rs
+++ b/xi-win-ui/src/lib.rs
@@ -23,6 +23,7 @@ use std::any::Any;
 use std::cell::RefCell;
 use std::char;
 use std::collections::BTreeMap;
+use std::ffi::OsString;
 use std::mem;
 use std::ops::{Deref, DerefMut};
 use std::time::Instant;
@@ -32,6 +33,7 @@ use direct2d::RenderTarget;
 use direct2d::render_target::GenericRenderTarget;
 use direct2d::brush::SolidColorBrush;
 
+pub use xi_win_shell::dialog::{FileDialogOptions, FileDialogType};
 use xi_win_shell::paint;
 use xi_win_shell::win_main;
 use xi_win_shell::window::{self, IdleHandle, MouseType, WindowHandle, WinHandler};
@@ -168,6 +170,17 @@ pub struct PaintCtx<'a, 'b: 'a>  {
     is_hot: bool,
     inner: &'a mut paint::PaintCtx<'b>,
     dwrite_factory: &'a directwrite::Factory,
+}
+
+#[derive(Debug)]
+pub enum Error {
+    ShellError(xi_win_shell::Error),
+}
+
+impl From<xi_win_shell::Error> for Error {
+    fn from(e: xi_win_shell::Error) -> Error {
+        Error::ShellError(e)
+    }
 }
 
 impl Geometry {
@@ -688,6 +701,13 @@ impl<'a> ListenerCtx<'a> {
     /// Request the window to be closed.
     pub fn close(&mut self) {
         self.c.handle.close();
+    }
+
+    pub fn file_dialog(&mut self, ty: FileDialogType, options: FileDialogOptions)
+        -> Result<OsString, Error>
+    {
+        let result = self.c.handle.file_dialog(ty, options)?;
+        Ok(result)
     }
 }
 


### PR DESCRIPTION
One of the items blocking #58 (the conversion to xi-win-ui).

Adds API surface to both xi-win-shell and xi-win-ui. Just one option is supported (hidden files).