### PR TITLE
Attach a console if available

### DIFF
--- a/xi-win-shell/Cargo.toml
+++ b/xi-win-shell/Cargo.toml
@@ -15,4 +15,4 @@ time = "0.1.39"
 
 [dependencies.winapi]
 version = "0.3.6"
-features = ["d2d1_1", "dwrite", "winbase", "libloaderapi", "errhandlingapi", "winuser", "shellscalingapi", "shobjidl", "combaseapi", "synchapi", "dxgi1_3", "dcomp", "d3d11", "dwmapi"]
+features = ["d2d1_1", "dwrite", "winbase", "libloaderapi", "errhandlingapi", "winuser", "shellscalingapi", "shobjidl", "combaseapi", "synchapi", "dxgi1_3", "dcomp", "d3d11", "dwmapi", "wincon", "fileapi", "processenv", "winbase"]


### PR DESCRIPTION
If we run within a console environment (e.g. from powershell), allocate
attach the console, so that we can easily write to stdout/stderr.