### PR TITLE
Graph mutation

### DIFF
--- a/src/edit_view.rs
+++ b/src/edit_view.rs
@@ -32,7 +32,7 @@ use directwrite::TextFormat;
 
 use xi_win_shell::window::{M_ALT, M_CTRL, M_SHIFT, MouseButton};
 
-use xi_win_ui::UiInner;
+use xi_win_ui::Ui;
 use xi_win_ui::widget::Widget;
 
 use xi_win_ui::{BoxConstraints, Geometry, LayoutResult};
@@ -235,7 +235,7 @@ impl EditView {
         }
     }
 
-    pub fn ui(self, ctx: &mut UiInner) -> Id {
+    pub fn ui(self, ctx: &mut Ui) -> Id {
         ctx.add(self, &[])
     }
 

--- a/xi-win-ui/examples/anim.rs
+++ b/xi-win-ui/examples/anim.rs
@@ -25,7 +25,7 @@ use direct2d::RenderTarget;
 use xi_win_shell::win_main;
 use xi_win_shell::window::WindowBuilder;
 
-use xi_win_ui::{UiMain, UiState, UiInner};
+use xi_win_ui::{UiMain, UiState, Ui};
 
 use xi_win_ui::{BoxConstraints, Geometry, LayoutResult};
 use xi_win_ui::{HandlerCtx, Id, LayoutCtx, MouseEvent, PaintCtx};
@@ -68,7 +68,7 @@ impl Widget for AnimWidget {
 }
 
 impl AnimWidget {
-    fn ui(self, ctx: &mut UiInner) -> Id {
+    fn ui(self, ctx: &mut Ui) -> Id {
         ctx.add(self, &[])
     }
 }

--- a/xi-win-ui/examples/dynamic.rs
+++ b/xi-win-ui/examples/dynamic.rs
@@ -1,0 +1,116 @@
+// Copyright 2018 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! An example of dynamic graph mutation.
+
+extern crate xi_win_shell;
+extern crate xi_win_ui;
+extern crate direct2d;
+extern crate directwrite;
+
+use std::collections::BTreeMap;
+
+use xi_win_shell::win_main;
+use xi_win_shell::window::WindowBuilder;
+
+use xi_win_ui::{Id, UiMain, UiState};
+use xi_win_ui::widget::{Button, Column, EventForwarder, Label, Row, Padding};
+
+#[derive(Default)]
+struct AppState {
+    count: usize,
+    buttons: BTreeMap<usize, Id>,
+    selected: Option<usize>,
+}
+
+#[derive(Clone)]
+enum Action {
+    AddButton,
+    DelButton,
+    Sort,
+    Select(usize),
+}
+
+fn main() {
+    xi_win_shell::init();
+
+    let mut run_loop = win_main::RunLoop::new();
+    let mut builder = WindowBuilder::new();
+    let mut state = UiState::new();
+    let label = Label::new("Selection: None").ui(&mut state);
+    let row1 = Row::new().ui(&[], &mut state);
+    let add_button = Button::new("Add").ui(&mut state);
+    let button1 = Padding::uniform(10.0).ui(add_button, &mut state);
+    let del_button = Button::new("Del").ui(&mut state);
+    let button2 = Padding::uniform(10.0).ui(del_button, &mut state);
+    let sort_button = Button::new("Sort").ui(&mut state);
+    let button3 = Padding::uniform(10.0).ui(sort_button, &mut state);
+    let row2 = Row::new().ui(&[button1, button2, button3], &mut state);
+    let col = Column::new().ui(&[label, row1, row2], &mut state);
+    let forwarder = EventForwarder::<Action>::new().ui(col, &mut state);
+    state.set_root(forwarder);
+    let mut app = AppState::default();
+    state.add_listener(forwarder, move |action: &mut Action, mut ctx| {
+        match action {
+            Action::AddButton => {
+                let n = app.count;
+                app.count += 1;
+                let label = format!("{}", n);
+                let new_button = Button::new(label).ui(&mut ctx);
+                println!("button {} id={}", n, new_button);
+                ctx.add_listener(new_button, move |_: &mut bool, mut ctx| {
+                    ctx.poke_up(&mut Action::Select(n));
+                });
+                let padded = Padding::uniform(10.0).ui(new_button, &mut ctx);
+                app.buttons.insert(n, padded);
+                if let Some(sibling) = app.selected {
+                    ctx.add_before(row1, app.buttons[&sibling], padded);
+                } else {
+                    ctx.append_child(row1, padded);
+                }
+            }
+            Action::DelButton => {
+                if let Some(n) = app.selected.take() {
+                    let id = app.buttons.remove(&n).unwrap();
+                    ctx.delete_child(row1, id);
+                    ctx.poke(label, &mut format!("Selection: {:?}", app.selected));
+                }
+            }
+            Action::Sort => {
+                for &child in app.buttons.values() {
+                    ctx.remove_child(row1, child);
+                    ctx.append_child(row1, child);
+                }
+            }
+            Action::Select(n) => {
+                app.selected = Some(*n);
+                ctx.poke(label, &mut format!("Selection: {:?}", app.selected));
+            }
+        }
+    });
+    state.add_listener(add_button, move |_: &mut bool, mut ctx| {
+        ctx.poke_up(&mut Action::AddButton);
+    });
+    state.add_listener(del_button, move |_: &mut bool, mut ctx| {
+        ctx.poke_up(&mut Action::DelButton);
+    });
+    state.add_listener(sort_button, move |_: &mut bool, mut ctx| {
+        ctx.poke_up(&mut Action::Sort);
+    });
+    builder.set_handler(Box::new(UiMain::new(state)));
+    builder.set_title("Dynamic example");
+    let window = builder.build().unwrap();
+    window.show();
+    run_loop.run();
+}

--- a/xi-win-ui/examples/sample.rs
+++ b/xi-win-ui/examples/sample.rs
@@ -26,7 +26,7 @@ use xi_win_shell::menu::Menu;
 use xi_win_shell::win_main;
 use xi_win_shell::window::WindowBuilder;
 
-use xi_win_ui::{UiMain, UiState, UiInner};
+use xi_win_ui::{UiMain, UiState, Ui};
 use xi_win_ui::widget::{Button, Row, Padding};
 use xi_win_ui::{FileDialogOptions, FileDialogType};
 
@@ -57,7 +57,7 @@ impl Widget for FooWidget {
 }
 
 impl FooWidget {
-    fn ui(self, ctx: &mut UiInner) -> Id {
+    fn ui(self, ctx: &mut Ui) -> Id {
         ctx.add(self, &[])
     }
 }

--- a/xi-win-ui/src/graph.rs
+++ b/xi-win-ui/src/graph.rs
@@ -1,0 +1,77 @@
+// Copyright 2018 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Graph for structure for widget tree.
+
+use std::mem;
+
+use Id;
+
+#[derive(Default)]
+pub struct Graph {
+    pub root: Id,
+    pub children: Vec<Vec<Id>>,
+    pub parent: Vec<Id>,
+
+    free_list: Vec<Id>,
+}
+
+impl Graph {
+    /// Allocate a node; it might be a previously freed id.
+    pub fn alloc_node(&mut self) -> Id {
+        if let Some(id) = self.free_list.pop() {
+            return id;
+        }
+        let id = self.children.len();
+        self.children.push(vec![]);
+        self.parent.push(id);
+        id
+    }
+
+    pub fn append_child(&mut self, parent: Id, child: Id) {
+        self.children[parent].push(child);
+        self.parent[child] = parent;
+    }
+
+    pub fn add_before(&mut self, parent: Id, sibling: Id, child: Id) {
+        let pos = self.children[parent].iter().position(|&x| x == sibling)
+            .expect("tried add_before nonexistent sibling");
+        self.children[parent].insert(pos, child);
+        self.parent[child] = parent;
+    }
+
+    /// Remove the child from the parent.
+    ///
+    /// Can panic if the graph structure is invalid. This function leaves the
+    /// child in an unparented state, i.e. it can be added again.
+    pub fn remove_child(&mut self, parent: Id, child: Id) {
+        let ix = self.children[parent].iter().position(|&x| x == child)
+            .expect("tried to remove nonexistent child");
+        self.children[parent].remove(ix);
+        self.parent[child] = child;
+    }
+
+    pub fn free_subtree(&mut self, node: Id) {
+        let mut ix = self.free_list.len();
+        // This is a little tricky; we're using the free list as a queue
+        // for breadth-first traversal.
+        self.free_list.push(node);
+        while ix < self.free_list.len() {
+            let node = self.free_list[ix];
+            ix += 1;
+            self.parent[node] = node;
+            self.free_list.extend(mem::replace(&mut self.children[node], Vec::new()));
+        }
+    }
+}

--- a/xi-win-ui/src/widget/button.rs
+++ b/xi-win-ui/src/widget/button.rs
@@ -23,7 +23,7 @@ use directwrite::{self, TextFormat, TextLayout};
 use xi_win_shell::util::default_text_options;
 
 use {BoxConstraints, Geometry, LayoutResult};
-use {HandlerCtx, Id, LayoutCtx, MouseEvent, PaintCtx, UiInner};
+use {HandlerCtx, Id, LayoutCtx, MouseEvent, PaintCtx, Ui};
 use widget::Widget;
 
 /// A text label with no interaction.
@@ -43,7 +43,7 @@ impl Label {
         }
     }
 
-    pub fn ui(self, ctx: &mut UiInner) -> Id {
+    pub fn ui(self, ctx: &mut Ui) -> Id {
         ctx.add(self, &[])
     }
 
@@ -99,7 +99,7 @@ impl Button {
         }
     }
 
-    pub fn ui(self, ctx: &mut UiInner) -> Id {
+    pub fn ui(self, ctx: &mut Ui) -> Id {
         ctx.add(self, &[])
     }
 }

--- a/xi-win-ui/src/widget/event_forwarder.rs
+++ b/xi-win-ui/src/widget/event_forwarder.rs
@@ -18,7 +18,7 @@ use std::any::Any;
 use std::marker::PhantomData;
 
 use widget::Widget;
-use {HandlerCtx, Id, UiInner};
+use {HandlerCtx, Id, Ui};
 
 pub struct EventForwarder<T>(PhantomData<T>);
 
@@ -27,7 +27,7 @@ impl<T: Any + Clone> EventForwarder<T> {
         EventForwarder(Default::default())
     }
 
-    pub fn ui(self, child: Id, ctx: &mut UiInner) -> Id {
+    pub fn ui(self, child: Id, ctx: &mut Ui) -> Id {
         ctx.add(self, &[child])
     }
 }

--- a/xi-win-ui/src/widget/flex.rs
+++ b/xi-win-ui/src/widget/flex.rs
@@ -17,7 +17,7 @@
 use std::collections::BTreeMap;
 
 use {BoxConstraints, LayoutResult};
-use {Id, LayoutCtx, UiInner};
+use {Id, LayoutCtx, Ui};
 use widget::Widget;
 
 pub struct Row;
@@ -125,7 +125,7 @@ impl Column {
 
 impl Flex {
     /// Add to UI with children.
-    pub fn ui(self, children: &[Id], ctx: &mut UiInner) -> Id {
+    pub fn ui(self, children: &[Id], ctx: &mut Ui) -> Id {
         ctx.add(self, children)
     }
 
@@ -238,5 +238,9 @@ impl Widget for Flex {
             },
         };
         LayoutResult::RequestChild(children[self.ix], child_bc)
+    }
+
+    fn on_child_removed(&mut self, child: Id) {
+        self.params.remove(&child);
     }
 }

--- a/xi-win-ui/src/widget/key_listener.rs
+++ b/xi-win-ui/src/widget/key_listener.rs
@@ -18,7 +18,7 @@ use winapi::um::winuser::*;
 use xi_win_shell::window::M_ALT;
 
 use widget::Widget;
-use {HandlerCtx, Id, KeyEvent, KeyVariant, UiInner};
+use {HandlerCtx, Id, KeyEvent, KeyVariant, Ui};
 
 pub struct KeyListener;
 
@@ -27,7 +27,7 @@ impl KeyListener {
         KeyListener
     }
 
-    pub fn ui(self, child: Id, ctx: &mut UiInner) -> Id {
+    pub fn ui(self, child: Id, ctx: &mut Ui) -> Id {
         ctx.add(self, &[child])
     }
 }

--- a/xi-win-ui/src/widget/mod.rs
+++ b/xi-win-ui/src/widget/mod.rs
@@ -33,6 +33,9 @@ pub use widget::flex::{Column, Flex, Row};
 mod key_listener;
 pub use widget::key_listener::KeyListener;
 
+mod null;
+pub(crate) use widget::null::NullWidget;
+
 mod padding;
 pub use widget::padding::Padding;
 
@@ -122,6 +125,10 @@ pub trait Widget {
     /// The method can also call `request_anim_frame` to keep the animation running.
     #[allow(unused)]
     fn anim_frame(&mut self, interval: u64, ctx: &mut HandlerCtx) {}
+
+    /// Called when a child widget is removed.
+    #[allow(unused)]
+    fn on_child_removed(&mut self, child: Id) {}
 }
 
 pub struct MouseEvent {

--- a/xi-win-ui/src/widget/null.rs
+++ b/xi-win-ui/src/widget/null.rs
@@ -1,0 +1,29 @@
+// Copyright 2018 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A null widget, used as a placeholder after deletion.
+
+use std::any::Any;
+
+use widget::Widget;
+use HandlerCtx;
+
+pub struct NullWidget;
+
+impl Widget for NullWidget {
+    fn poke(&mut self, _payload: &mut Any, _ctx: &mut HandlerCtx) -> bool {
+        eprintln!("Poke to null widget: probable use-after-free");
+        true
+    }
+}

--- a/xi-win-ui/src/widget/padding.rs
+++ b/xi-win-ui/src/widget/padding.rs
@@ -15,7 +15,7 @@
 //! A widget that just adds padding during layout.
 
 use {BoxConstraints, LayoutResult};
-use {Id, LayoutCtx, UiInner};
+use {Id, LayoutCtx, Ui};
 use widget::Widget;
 
 /// A padding widget. Is expected to have exactly one child.
@@ -37,7 +37,7 @@ impl Padding {
         }
     }
 
-    pub fn ui(self, child: Id, ctx: &mut UiInner) -> Id {
+    pub fn ui(self, child: Id, ctx: &mut Ui) -> Id {
         ctx.add(self, &[child])
     }
 }


### PR DESCRIPTION
Allow mutation of the graph from inside listener contexts, not just
during building. The `UiInner` struct has been renamed `Ui`.

This patch adds an `append_child` method, and also does a bit of
refactoring so that listeners can be added. It adds remove (suitable
for moving widgets in the tree) and full deletion. When widgets are
deleted, they're fully cleaned up, with listeners removed and the id
available for resuse.

There's also an example which exercises the new APIs.